### PR TITLE
Ability to handle results from multiple apriltags

### DIFF
--- a/synapse_core/src/synapse/core/runtime_handler.py
+++ b/synapse_core/src/synapse/core/runtime_handler.py
@@ -955,9 +955,20 @@ class RuntimeManager:
                         )
 
     def updateSetting(self, prop: str, cameraIndex: CameraID, value: Any) -> None:
-        self.pipelineLoader.getPipelineSettings(
+        settings = self.pipelineLoader.getPipelineSettings(
             self.pipelineBindings[cameraIndex]
-        ).setSetting(prop, value)
+        )
+        settings.setSetting(prop, value)
+        pipeline = self.pipelineLoader.getPipeline(self.pipelineBindings[cameraIndex])
+
+        if pipeline is not None:
+            setting = settings.getAPI().getSetting(prop)
+            if setting is not None:
+                pipeline.onSettingChanged(setting, settings.getSetting(prop))
+            else:
+                log.warn(
+                    f"Attempted to set setting {prop} on pipeline #{pipeline.pipelineIndex} but it was not found!"
+                )
 
         camera = self.cameraHandler.getCamera(cameraIndex)
         if camera is not None:

--- a/synapse_core/src/synapse/core/settings_api.py
+++ b/synapse_core/src/synapse/core/settings_api.py
@@ -592,6 +592,17 @@ class SettingsAPI:
 
         return result
 
+    def getSetting(self, prop: str) -> Optional[Setting]:
+        """Retrieves the setting object for a given key.
+
+        Args:
+            prop (str): The key of the setting to retrieve.
+
+        Returns:
+            Optional[Setting]: The Setting object if found, otherwise None.
+        """
+        return self.settings.get(prop)
+
     def getValue(self, key: str) -> Any:
         """Retrieves the current value of a setting.
 
@@ -991,7 +1002,7 @@ class PipelineSettings(SettingsCollection):
     )
 
     def setSetting(self, setting: Union[Setting, str], value: SettingsValue) -> None:
-        return super().setSetting(setting, value)
+        super().setSetting(setting, value)
 
 
 def protoToSettingValue(proto: SettingValueProto) -> SettingsValue:

--- a/synapse_core/src/synapse/pipelines/apriltag/apriltag_detector.py
+++ b/synapse_core/src/synapse/pipelines/apriltag/apriltag_detector.py
@@ -4,7 +4,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Iterable, List, Protocol, Tuple
 
 import cv2
 import numpy as np
@@ -197,6 +197,11 @@ class ApriltagPoseEstimator(ABC):
 
     @abstractmethod
     def getConfig(self) -> Config: ...
+
+
+class ICombinedApriltagRobotPoseEstimator(Protocol):
+    @staticmethod
+    def estimate(tags: Iterable[RobotPoseEstimate], **kwargs) -> Pose3d: ...
 
 
 def drawTagDetectionMarker(

--- a/synapse_core/src/synapse/pipelines/apriltag/apriltag_detector.py
+++ b/synapse_core/src/synapse/pipelines/apriltag/apriltag_detector.py
@@ -146,6 +146,9 @@ class AprilTagDetector(ABC):
         """
         ...
 
+    @abstractmethod
+    def getConfig(self) -> Config: ...
+
 
 class ApriltagPoseEstimator(ABC):
     """Abstract base class for AprilTag pose estimators."""
@@ -191,6 +194,9 @@ class ApriltagPoseEstimator(ABC):
             config (Config): Pose estimation configuration.
         """
         ...
+
+    @abstractmethod
+    def getConfig(self) -> Config: ...
 
 
 def drawTagDetectionMarker(

--- a/synapse_core/src/synapse/pipelines/apriltag/apriltag_robotpy.py
+++ b/synapse_core/src/synapse/pipelines/apriltag/apriltag_robotpy.py
@@ -44,6 +44,12 @@ class RobotpyApriltagDetector(AprilTagDetector):
 
         self.detector.setConfig(rpy_config)
 
+    def getConfig(self) -> AprilTagDetector.Config:
+        config = self.detector.getConfig()
+        return self.Config(
+            config.numThreads, config.refineEdges, config.quadDecimate, config.quadSigma
+        )
+
 
 class RobotpyApriltagPoseEstimator(ApriltagPoseEstimator):
     def __init__(self, config: ApriltagPoseEstimator.Config) -> None:
@@ -76,3 +82,9 @@ class RobotpyApriltagPoseEstimator(ApriltagPoseEstimator):
         estimatorConfig.fy = config.fy
         estimatorConfig.cx = config.cx
         estimatorConfig.cy = config.cy
+
+    def getConfig(self) -> ApriltagPoseEstimator.Config:
+        config = self.estimator.getConfig()
+        return ApriltagPoseEstimator.Config(
+            config.cx, config.cy, config.fx, config.fy, config.tagSize
+        )

--- a/synapse_core/src/synapse/pipelines/apriltag/multi_tag_estimator.py
+++ b/synapse_core/src/synapse/pipelines/apriltag/multi_tag_estimator.py
@@ -42,7 +42,7 @@ class WeightedAverageMultiTagEstimator(ICombinedApriltagRobotPoseEstimator):
 
             # Collect weighted quaternion
             rot = pose.rotation()
-            q = rot.getQuaternion()
+            q: Quaternion = rot.getQuaternion()
             weighted_quats.append((q, weight))
 
         # Average translation
@@ -53,10 +53,10 @@ class WeightedAverageMultiTagEstimator(ICombinedApriltagRobotPoseEstimator):
         # Weighted quaternion average
         qw, qx, qy, qz = 0.0, 0.0, 0.0, 0.0
         for q, w in weighted_quats:
-            qw += q.w * w
-            qx += q.x * w
-            qy += q.y * w
-            qz += q.z * w
+            qw += q.W() * w
+            qx += q.X() * w
+            qy += q.Y() * w
+            qz += q.Z() * w
         norm = math.sqrt(qw * qw + qx * qx + qy * qy + qz * qz)
         if norm > 1e-9:
             qw, qx, qy, qz = qw / norm, qx / norm, qy / norm, qz / norm

--- a/synapse_core/src/synapse/pipelines/apriltag/multi_tag_estimator.py
+++ b/synapse_core/src/synapse/pipelines/apriltag/multi_tag_estimator.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2025 Dan Peled
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import math
+from typing import Iterable
+
+from wpimath.geometry import Pose3d, Quaternion, Rotation3d
+
+from .apriltag_detector import (ICombinedApriltagRobotPoseEstimator,
+                                RobotPoseEstimate)
+
+
+class WeightedAverageMultiTagEstimator(ICombinedApriltagRobotPoseEstimator):
+    @staticmethod
+    def estimate(tags: Iterable[RobotPoseEstimate], **kwargs) -> Pose3d:
+        tags = list(tags)
+        if not tags:
+            return Pose3d()  # identity if no detections
+
+        # --- Weighted average translation ---
+        weighted_x, weighted_y, weighted_z = 0.0, 0.0, 0.0
+        total_weight = 0.0
+
+        # Store quaternions + weights
+        weighted_quats = []
+
+        for t in tags:
+            pose = t.robotPose_fieldSpace
+
+            # Distance from robot to tag (in field space)
+            # (You could also use camera-to-tag transform length here)
+            dist = pose.translation().norm()
+
+            # Weight = inverse distance (closer tag → higher weight)
+            weight = 1.0 / max(dist, 1e-6)
+
+            weighted_x += pose.x * weight
+            weighted_y += pose.y * weight
+            weighted_z += pose.z * weight
+            total_weight += weight
+
+            # Collect weighted quaternion
+            rot = pose.rotation()
+            q = rot.getQuaternion()
+            weighted_quats.append((q, weight))
+
+        # Average translation
+        avg_x = weighted_x / total_weight
+        avg_y = weighted_y / total_weight
+        avg_z = weighted_z / total_weight
+
+        # Weighted quaternion average
+        qw, qx, qy, qz = 0.0, 0.0, 0.0, 0.0
+        for q, w in weighted_quats:
+            qw += q.w * w
+            qx += q.x * w
+            qy += q.y * w
+            qz += q.z * w
+        norm = math.sqrt(qw * qw + qx * qx + qy * qy + qz * qz)
+        if norm > 1e-9:
+            qw, qx, qy, qz = qw / norm, qx / norm, qy / norm, qz / norm
+
+        avg_rot = Quaternion(qw, qx, qy, qz)
+
+        return Pose3d(avg_x, avg_y, avg_z, Rotation3d(avg_rot))


### PR DESCRIPTION
# Pull Request
Closes #10 

- Abstraction for combining multiple apriltag results into 1 final robot pose estimation
- Adds `onSettingChaned` function in `Pipeline`
- Logic fixings
- New form for ApriltagResult

---

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [x] 💥 Breaking change
- [x] 🧼 Refactor
- [ ] 📝 Documentation update
- [ ] 🧪 Tests added or updated
- [ ] Other (describe)

---

## Checklist

- [x] Code builds and passes all relevant tests
- [ ] Unit tests were added or updated for all new logic
- [ ] Code is documented or self-documenting
- [ ] I’ve updated related docs/README if needed
- [x] I’ve manually tested changes where applicable
- [ ] I’ve ensured compatibility across affected subprojects