### PR TITLE
Refactor SynapseCamera with full JavaDoc, typed settings, and cached NT entries

### DIFF
--- a/synapse_lib/src/test/java/synapse/SynapseCameraTest.java
+++ b/synapse_lib/src/test/java/synapse/SynapseCameraTest.java
@@ -2,10 +2,12 @@ package synapse;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
@@ -26,8 +28,10 @@ class SynapseCameraTest {
     byte[] serialized =
         new ObjectMapper(new MessagePackFactory()).writeValueAsBytes(new int[] {1, 2, 3});
 
-    int[] results = camera.getResults(new TypeReference<int[]>() {}, serialized);
-    assertArrayEquals(new int[] {1, 2, 3}, results);
+    Optional<int[]> results = camera.getResults(new TypeReference<int[]>() {}, serialized);
+
+    assertTrue(results.isPresent());
+    assertArrayEquals(new int[] {1, 2, 3}, results.get());
   }
 
   @Test
@@ -43,8 +47,10 @@ class SynapseCameraTest {
 
     byte[] serialized = mapper.writeValueAsBytes(original);
 
-    ApriltagResult results = camera.getResults(new TypeReference<ApriltagResult>() {}, serialized);
+    Optional<ApriltagResult> results =
+        camera.getResults(new TypeReference<ApriltagResult>() {}, serialized);
 
-    assertEquals(results, original);
+    assertTrue(results.isPresent());
+    assertEquals(results.get(), original);
   }
 }


### PR DESCRIPTION
- Added comprehensive JavaDoc comments for all fields, methods, constructors, and nested classes
- Introduced typed Setting class for safer camera configuration access
- Replaced repeated NetworkTableEntry lookups with cached entries for performance
- Added factory methods for common setting types (Double, String, arrays)
- Ensured all NetworkTable access is null-safe and type-checked
- Preserved existing functionality for pipelines, recording, results, and latency

---

## Type of Change

- [ ] 🐛 Bug fix
- [x] 🚀 New feature
- [x] 💥 Breaking change
- [x] 🧼 Refactor
- [ ] 📝 Documentation update
- [ ] 🧪 Tests added or updated
- [ ] Other (describe)

---

## Checklist

- [x] Code builds and passes all relevant tests
- [x] Unit tests were added or updated for all new logic
- [x] Code is documented or self-documenting
- [ ] I’ve updated related docs/README if needed
- [x] I’ve manually tested changes where applicable
- [x] I’ve ensured compatibility across affected subprojects