### PR TITLE
Switch to using subscribers instead of entries for synapselib

### DIFF
--- a/synapse_core/src/synapse/core/pipeline.py
+++ b/synapse_core/src/synapse/core/pipeline.py
@@ -97,8 +97,7 @@ class Pipeline(ABC, Generic[TSettingsType, TResultType]):
         Cleanup before processing a new frame.
         Resets results and invalidates NT cache.
         """
-        self.setResults(None)
-        # self.invalidateCachedEntries()
+        ...
 
     def invalidateCachedEntries(self) -> None:
         """
@@ -132,7 +131,9 @@ class Pipeline(ABC, Generic[TSettingsType, TResultType]):
         Set a value in NetworkTables and optionally send via WebSocket.
         Supports all NT-compatible types.
         """
-        if isinstance(value, (bytes, int, float, str, bool)):
+        if value == bytes():
+            parsed = 0
+        elif isinstance(value, (bytes, int, float, str, bool)):
             parsed: Any = value
         elif isinstance(value, (list, tuple)) and all(
             isinstance(x, (int, float, bytes, bool)) for x in value
@@ -162,7 +163,7 @@ class Pipeline(ABC, Generic[TSettingsType, TResultType]):
         """Set the pipeline result in NT."""
         self.setDataValue(
             ResultsTopicKey,
-            serializePipelineResult(value) if value is not None else 0,
+            serializePipelineResult(value) if value is not None else bytes(),
             isMsgpack=True,
         )
 

--- a/synapse_core/src/synapse/core/pipeline_handler.py
+++ b/synapse_core/src/synapse/core/pipeline_handler.py
@@ -276,6 +276,9 @@ class PipelineHandler:
 
         pipelines = loadPipelineClasses(directory)
         if not is_inside(Path(__file__), directory):
+            # When running on coprocessor, this file's root dir
+            # is as the same as the main.py file which will result
+            # in reading this file twice when reading from the project dir and this dir
             pipelines.update(loadPipelineClasses(Path(__file__).parent.parent))
 
         log.log("Loaded pipeline classes successfully")

--- a/synapse_lib/src/test/java/synapse/SynapseCameraTest.java
+++ b/synapse_lib/src/test/java/synapse/SynapseCameraTest.java
@@ -28,7 +28,7 @@ class SynapseCameraTest {
     byte[] serialized =
         new ObjectMapper(new MessagePackFactory()).writeValueAsBytes(new int[] {1, 2, 3});
 
-    Optional<int[]> results = camera.getResults(new TypeReference<int[]>() {}, serialized);
+    Optional<int[]> results = camera.deserializeResults(new TypeReference<int[]>() {}, serialized);
 
     assertTrue(results.isPresent());
     assertArrayEquals(new int[] {1, 2, 3}, results.get());
@@ -48,7 +48,7 @@ class SynapseCameraTest {
     byte[] serialized = mapper.writeValueAsBytes(original);
 
     Optional<ApriltagResult> results =
-        camera.getResults(new TypeReference<ApriltagResult>() {}, serialized);
+        camera.deserializeResults(new TypeReference<ApriltagResult>() {}, serialized);
 
     assertTrue(results.isPresent());
     assertEquals(results.get(), original);


### PR DESCRIPTION
Also removes periodic removal of results, results emptying currently handled by pipeline